### PR TITLE
Change include_descriptors default to None and better handling of label names 

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -17,7 +17,7 @@ dependencies:
   - transformers
   - datasets
   - tokenizers
-  - accelerate >=0.28.0 # for accelerator_config update
+  - accelerate >=0.33 # for accelerator_config update
   - evaluate
   - wandb
   - huggingface_hub
@@ -29,19 +29,17 @@ dependencies:
   - black >=24
   - ruff
   - pytest >=6.0
-  - nbconvert
   - jupyterlab
   - nbconvert
   - ipywidgets
 
   - pip:
-    - mkdocs <1.6.0
-    - mkdocs-material >=7.1.1
-    - mkdocs-material-extensions
-    - mkdocstrings
-    - mkdocstrings-python
-    - mkdocs-jupyter
-    - markdown-include
-    - markdown-include
-    - mdx_truly_sane_lists
-    - mike >=1.0.0
+      - mkdocs <1.6.0
+      - mkdocs-material >=7.1.1
+      - mkdocs-material-extensions
+      - mkdocstrings
+      - mkdocstrings-python
+      - mkdocs-jupyter
+      - markdown-include
+      - mdx_truly_sane_lists
+      - mike >=1.0.0

--- a/safe/trainer/cli.py
+++ b/safe/trainer/cli.py
@@ -46,7 +46,7 @@ class ModelArguments:
         default=None, metadata={"help": "Optional number of labels for the descriptors"}
     )
     include_descriptors: Optional[bool] = field(
-        default=True,
+        default=False,
         metadata={"help": "Whether to train with descriptors if they are available or Not"},
     )
     prop_loss_coeff: Optional[float] = field(
@@ -331,7 +331,8 @@ def train(model_args, data_args, training_args):
 
     if model_args.include_descriptors:
         training_args.label_names = ["labels", "mc_labels"]
-
+    else:
+        training_args.label_names = ["labels"]
     # update dispatch_batches in accelerator
     training_args.accelerator_config.dispatch_batches = data_args.streaming is not True
 

--- a/safe/trainer/cli.py
+++ b/safe/trainer/cli.py
@@ -331,7 +331,8 @@ def train(model_args, data_args, training_args):
 
     if model_args.include_descriptors:
         training_args.label_names = ["labels", "mc_labels"]
-    else:
+
+    if training_args.label_names is None:
         training_args.label_names = ["labels"]
     # update dispatch_batches in accelerator
     training_args.accelerator_config.dispatch_batches = data_args.streaming is not True

--- a/safe/trainer/collator.py
+++ b/safe/trainer/collator.py
@@ -95,10 +95,10 @@ class SAFECollator:
 
         # If special token mask has been preprocessed, pop it from the dict.
         batch.pop("special_tokens_mask", None)
-        labels = batch.get("labels", batch["input_ids"].clone())
+        labels = batch.get(self.label_key, batch["input_ids"].clone())
         if tokenizer.pad_token_id is not None:
             labels[labels == tokenizer.pad_token_id] = -100
-        batch["labels"] = labels
+        batch[self.label_key] = labels
 
         if mc_labels is not None and self.include_descriptors:
             batch.update(


### PR DESCRIPTION
## Changelogs

- include_descriptors is not disabled by default and label_names does not need to be provided to get eval loss.
---

_Checklist:_

- [ ] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [ ] _Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._
- [x] _Write concise and explanatory changelogs below._
- [ ] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

See #49 