### PR TITLE
Support RDKit extended ring closures for molecules with >= 100 ring bonds

### DIFF
--- a/safe/converter.py
+++ b/safe/converter.py
@@ -105,6 +105,23 @@ class SAFEConverter:
         atom_indices = rng.permutation(atom_indices).tolist()
         return Chem.RenumberAtoms(mol, atom_indices)
 
+    @staticmethod
+    def _format_ring_closure(num: int) -> str:
+        """Format a ring-closure (branch) number into its SMILES token.
+
+        Single digits stay bare (e.g. ``5``), two-digit numbers use the ``%NN``
+        form, and numbers >= 100 use RDKit's extended ``%(nnn)`` ring-closure
+        notation (see https://www.rdkit.org/docs/RDKit_Book.html#ring-closures).
+
+        Args:
+            num: ring-closure number to format
+        """
+        if num < 10:
+            return str(num)
+        if num < 100:
+            return f"%{num}"
+        return f"%({num})"
+
     @classmethod
     def _find_branch_number(cls, inp: str):
         """Find the branch number and ring closure in the SMILES representation using regexp
@@ -113,16 +130,18 @@ class SAFEConverter:
             inp: input smiles
         """
         inp = re.sub(r"\[.*?\]", "", inp)  # noqa
-        matching_groups = re.findall(r"((?<=%)\d{2})|((?<!%)\d+)(?![^\[]*\])", inp)
-        # first match is for multiple connection as multiple digits
-        # second match is for single connections requiring 2 digits
-        # SMILES does not support triple digits
+        matching_groups = re.findall(r"(?<=%)\((\d+)\)|(?<=%)(\d{2})|((?<!%)\d+)(?![^\[]*\])", inp)
+        # first match is the extended '%(nnn)' ring closure (a single label)
+        # second match is for two-digit '%NN' ring closures
+        # third match is for plain digits, each one a single-digit ring closure
         branch_numbers = []
-        for m in matching_groups:
-            if m[0] == "":
-                branch_numbers.extend(int(mm) for mm in m[1])
-            elif m[1] == "":
-                branch_numbers.append(int(m[0].replace("%", "")))
+        for extended, double, single in matching_groups:
+            if extended:
+                branch_numbers.append(int(extended))
+            elif double:
+                branch_numbers.append(int(double))
+            elif single:
+                branch_numbers.extend(int(d) for d in single)
         return branch_numbers
 
     def _ensure_valid(self, inp: str):
@@ -139,11 +158,10 @@ class SAFEConverter:
         branch_numbers = Counter(branch_numbers)
         for i, (bnum, bcount) in enumerate(branch_numbers.items()):
             if bcount % 2 != 0:
-                bnum_str = str(bnum) if bnum < 10 else f"%{bnum}"
+                bnum_str = self._format_ring_closure(bnum)
                 _tk = f"[*:{i+1}]{bnum_str}"
                 if self.use_original_opener_for_attach:
-                    bnum_digit = bnum_str.strip("%")  # strip out the % sign
-                    _tk = f"[*:{bnum_digit}]{bnum_str}"
+                    _tk = f"[*:{bnum}]{bnum_str}"
                 missing_tokens.append(_tk)
         return ".".join(missing_tokens)
 
@@ -261,8 +279,9 @@ class SAFEConverter:
         # EN: we first normalize the attachment if the molecule is a query:
         # inp = dm.reactions.convert_attach_to_isotope(inp, as_smiles=True)
 
-        # TODO(maclandrol): RDKit supports some extended form of ring closure, up to 5 digits
-        # https://www.rdkit.org/docs/RDKit_Book.html#ring-closures and I should try to include them
+        # RDKit's extended ring-closure form ('%(nnn)', up to 5 digits) is used for
+        # labels >= 100; see `_format_ring_closure`.
+        # https://www.rdkit.org/docs/RDKit_Book.html#ring-closures
         branch_numbers = self._find_branch_number(inp)
 
         mol = dm.to_mol(inp, remove_hs=False)
@@ -345,14 +364,14 @@ class SAFEConverter:
             attach_pos = sorted(attach_pos)
         starting_num = 1 if len(scf_branch_num) == 0 else max(scf_branch_num) + 1
         for attach in attach_pos:
-            val = str(starting_num) if starting_num < 10 else f"%{starting_num}"
+            val = self._format_ring_closure(starting_num)
             # we cannot have anything of the form "\([@=-#-$/\]*\d+\)"
             attach_regexp = re.compile(r"(" + re.escape(attach) + r")")
             scaffold_str = attach_regexp.sub(val, scaffold_str)
             starting_num += 1
 
         # now we need to remove all the parenthesis around digit only number
-        wrong_attach = re.compile(r"\(([\%\d]*)\)")
+        wrong_attach = re.compile(r"(?<!%)\((%\(\d+\)|[\%\d]*)\)")
         scaffold_str = wrong_attach.sub(r"\g<1>", scaffold_str)
         # furthermore, we autoapply rdkit-compatible digit standardization.
         if rdkit_safe:

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -146,3 +146,40 @@ def test_stereochemistry_issue():
     # check if we ignore the stereo
     output = safe.encode(STEREO_MOL_LIST[0], ignore_stereo=True, slicer="brics")
     assert dm.same_mol(dm.remove_stereochemistry(dm.to_mol(STEREO_MOL_LIST[0])), output)
+
+
+def test_large_molecule_ring_closures():
+    # A long peptide produces > 99 SAFE fragments, whose attachment bonds need
+    # the %(nnn) extended ring-closure form to be valid SMILES.
+    from rdkit import Chem
+
+    seq = "LVYTDCTESGQNLCLCEGSNVCGQGNKCILGSDGEKNQCVTGEGTPKPQSHNDGDFEEIPEEYLQ"
+    smiles = Chem.MolToSmiles(Chem.MolFromSequence(seq))
+    encoded = safe.encode(smiles, canonical=True)
+    assert "%(" in encoded  # uses extended ring closures
+    assert dm.same_mol(smiles, safe.decode(encoded))
+
+
+def test_extended_ring_closure_decoding():
+    # The decoder must understand RDKit's extended '%(nnn)' ring-closure form,
+    # both when reading branch numbers and when completing unpaired attachment
+    # points.
+    from rdkit import Chem
+
+    conv = safe.SAFEConverter()
+
+    # '%(nnn)' is a single ring-closure label, not three separate digits
+    assert conv._find_branch_number("C%(100)") == [100]
+    assert conv._find_branch_number("c1ccccc1%(123)") == [1, 1, 123]
+    # plain single-digit and two-digit forms keep their existing behaviour
+    assert conv._find_branch_number("C1CC%23C") == [1, 23]
+
+    # an unpaired extended label must be completed into a valid molecule
+    assert dm.to_mol(conv._ensure_valid("C%(100)")) is not None
+
+    # fragment-level decoding of a >99 ring-closure molecule must not silently fail
+    seq = "LVYTDCTESGQNLCLCEGSNVCGQGNKCILGSDGEKNQCVTGEGTPKPQSHNDGDFEEIPEEYLQ"
+    encoded = safe.encode(Chem.MolToSmiles(Chem.MolFromSequence(seq)), canonical=True)
+    decoded_fragments = [safe.decode(fragment, fix=True) for fragment in encoded.split(".")]
+    assert all(x is not None for x in decoded_fragments)
+    assert safe.decode(encoded, as_mol=True) is not None


### PR DESCRIPTION
## Changelogs

- Fix SAFE encoding for molecules with **≥100 ring-closure bonds**. The `encoder()` wrote ring labels greater or equal to 10 as `f"%{n}"`, so a label greater or equal to 100 becomes a bare `%101`. Since SMILES reads exactly two digits after `%`, RDKit parsed it as `%10` + `1`, causing wrong bonds / valence errors / `SAFEDecodeError`. Labels ≥100 are now written in RDKit's extended `%(nnn)` form, resolving the existing `# TODO(maclandrol)` about extended ring closures.
- Fix SAFE decoding for extended ring closures. `_find_branch_number` split `%(nnn)` into separate digits, and `_ensure_valid` re-emitted an unpaired label greater than or equal to 100 as the invalid `%nnn`. So decoding *individual fragments* with a ring-closure label of greater or equal to 100 silently returned `None` (`as_mol=False`) or raised `SAFEDecodeError` (`as_mol=True`). Both helpers now understand the extended `%(nnn)` form, and ring-label formatting is centralized in a shared `_format_ring_closure` helper used by both the encoder and decoder.
- Update the `wrong_attach` paren-stripping regex (`(?<!%)\((%\(\d+\)|[\%\d]*)\)`) so the branch parenthesis around a ring label is still removed, while a standalone `%(nnn)` is preserved. (This also fixes a latent case where RDKit's own `%(nnn)` fragment ring closures were being corrupted by the stripper.)
- Add a round-trip test for a large molecule (a 65-residue peptide, >99 ring bonds), as well as a test for extended ring closure decoding.

---

_Checklist:_

- [x] _Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate)._
- [x] _Update the API documentation if a new function is added, or an existing one is deleted. Eventually consider making a new tutorial for new features._
- [x] _Write concise and explanatory changelogs below._
- [x] _If possible, assign one of the following labels to the PR: `feature`, `fix` or `test` (or ask a maintainer to do it for you)._

---

## Summary

In `SAFEConverter.encoder`, attachment ring labels are formatted as `str(n)` for n < 10 and `f"%{n}"` otherwise. The `%{n}` form is correct for 10–99 but invalid for labels greater than or equal to 100, because `%` is a fixed two-digit ring-closure token in SMILES (the three-digit form is `%(nnn)`). Thus, any molecule needing more than 99 ring-closure labels in total fails to round-trip. In practice this caps SAFE at approximately 50-residue peptides as BRICS yields ~2 fragments/residue, i.e. ~2 ring bonds each.

## Reproduction

This bug has two failure modes. For a given molecule `encoded`:

- When `safe.decode(encoded, as_mol=True)` is called, the SAFE string cannot be parsed (`dm.to_mol` returns `None`), leading to a `SAFEDecodeError` as `dm.remove_hs(None)` is called. (first example below)
- When `safe.decode(encoded)` (default `as_mol=False`) is called, it silently returns `None`, and an assertion of `dm.same_mol(...)` will return `False`. (second example below)

**Reproduced on safe-mol 0.1.14, `as_mol=True`:**

```python
import re
import safe
from rdkit import Chem

# 45-residue peptide: BRICS yields >99 fragments, so attachment ring labels exceed 99
mol = Chem.MolFromSequence("ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWYACDEF")
encoded = safe.encode(mol, canonical=True)

print(re.findall(r"%\d{3,}", encoded)[:6])  # ['%101', '%103', '%100', '%100', '%101', '%102']

safe.decode(encoded, as_mol=True)  # raises safe.SAFEDecodeError
```

**Output**:

```bash
safe._exception.SAFEDecodeError: Failed to decode C%38(=O)[C@@H]%48CCC(=O)O.c1%101c[nH]c2ccccc12.C%10(=O)[C@@H]%61CCC(N)=O. C%15(=O)[C@@H]%65CCCCN.C%21(=O)[C@@H]%70CCC(=O)O. ... .c1%103c[nH]c2ccccc12. ... .c1%100ccc(O)cc1. ... .C%82(=O)[C@@H]%53C%100.C%93(=O)[C@@H]%54C%101. ...
```

Here, 3-digit tokens like C%101 are read by RDKit as %10 and 1, which mis-bonds the structure, leading to a subsequent failure in `dm.remove_hs(None)`.

**Reproduction of `as_mol=False` silent return**:

```python
import re
import safe
import datamol as dm
from rdkit import Chem

# 45-residue peptide: BRICS yields >99 fragments, so attachment ring labels exceed 99
mol = Chem.MolFromSequence("ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWYACDEF")
encoded = safe.encode(mol, canonical=True)

print(re.findall(r"%\d{3,}", encoded)[:6])  # ['%101', '%103', '%100', '%100', '%101', '%102']

smi = safe.decode(encoded)  # defaults to `as_mol=False`
assert dm.same_mol(mol, smi)  # AssertionError
```

**Decoder failure**:

```python
import safe

safe.decode("c1%(101)c[nH]c2ccccc12", fix=True)  # returns `None` before the decoder fix
```

## Testing

`tests/test_safe.py` passes except for `test_stereochemistry_issue`, which is a pre-existing failure on `main` and is unrelated to this PR.